### PR TITLE
Perbaiki error halaman kelola soal

### DIFF
--- a/exams.php
+++ b/exams.php
@@ -276,6 +276,11 @@ foreach ($exams as $exam):
         </div>
         <div class="flex justify-end space-x-2 mt-3">
             <a href="?action=download&id=<?php echo $exam['id']; ?>" class="text-purple-500 hover:text-purple-700 text-sm font-medium">⬇️ Unduh</a>
+            <form method="POST" style="display:inline;" onsubmit="return confirm('Hapus file soal ini?')">
+                <input type="hidden" name="action" value="delete_exam">
+                <input type="hidden" name="id" value="<?php echo $exam['id']; ?>">
+                <button type="submit" class="bg-red-100 text-red-700 px-3 py-1 rounded text-xs font-semibold hover:bg-red-200">🗑️ Hapus</button>
+            </form>
         </div>
     </div>
 <?php endforeach; ?>

--- a/exams.php
+++ b/exams.php
@@ -259,22 +259,26 @@ $exams = getExams();
                     // Pastikan $db sudah diinisialisasi
                     if (!isset($db) || !$db) { $db = getDbConnection(); }
                     // Tampilkan file ujian (type=file)
-                    $stmtFiles = $db->query("SELECT * FROM exams WHERE type = 'file'");
-                    $fileExams = $stmtFiles->fetchAll(PDO::FETCH_ASSOC);
-                    foreach ($fileExams as $exam): ?>
-                        <div class="bg-gray-50 rounded-lg p-4 border border-gray-200">
-                            <div class="flex items-start justify-between mb-2">
-                                <div class="flex-1">
-                                    <p class="text-sm text-gray-600">Mata Pelajaran: <?php echo htmlspecialchars($exam['subject_name']); ?></p>
-                                    <p class="text-sm text-gray-600">File: <?php echo htmlspecialchars($exam['file_name']); ?></p>
-                                    <span class="inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full mt-1">📁 File Ujian</span>
-                                </div>
-                            </div>
-                            <div class="flex justify-end space-x-2 mt-3">
-                                <a href="?action=download&id=<?php echo $exam['id']; ?>" class="text-purple-500 hover:text-purple-700 text-sm font-medium">⬇️ Unduh</a>
-                            </div>
-                        </div>
-                    <?php endforeach; ?>
+                    // $stmtFiles = $db->query("SELECT * FROM exams WHERE type = 'file'");
+                    // $fileExams = $stmtFiles->fetchAll(PDO::FETCH_ASSOC);
+                    // foreach ($fileExams as $exam): ?>
+<?php
+foreach ($exams as $exam):
+    if ($exam['type'] !== 'file') continue;
+?>
+    <div class="bg-gray-50 rounded-lg p-4 border border-gray-200">
+        <div class="flex items-start justify-between mb-2">
+            <div class="flex-1">
+                <p class="text-sm text-gray-600">Mata Pelajaran: <?php echo htmlspecialchars($exam['subject_name']); ?></p>
+                <p class="text-sm text-gray-600">File: <?php echo htmlspecialchars($exam['file_name']); ?></p>
+                <span class="inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full mt-1">📁 File Ujian</span>
+            </div>
+        </div>
+        <div class="flex justify-end space-x-2 mt-3">
+            <a href="?action=download&id=<?php echo $exam['id']; ?>" class="text-purple-500 hover:text-purple-700 text-sm font-medium">⬇️ Unduh</a>
+        </div>
+    </div>
+<?php endforeach; ?>
                     <?php
                     // Ambil semua kombinasi kelas-mapel yang ada soal
                     $db = getDbConnection();


### PR DESCRIPTION
Fix 'Undefined array key' warning and file exam card duplication, and add delete functionality for file exams.

The previous display logic for file exam cards used a separate database query that lacked joined subject and class names, causing an 'Undefined array key' warning. It also led to duplicate card displays on page refresh. This PR refactors the display to correctly use the already fetched `$exams` data, which includes the necessary joined fields, and filters for `type='file'` to prevent duplication. Additionally, a delete button is added to each file exam card for direct removal.

---

[Open in Web](https://www.cursor.com/agents?id=bc-e7f09eda-49ec-4e97-8c90-31ab81737d00) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e7f09eda-49ec-4e97-8c90-31ab81737d00)